### PR TITLE
Update wiki template

### DIFF
--- a/CreateDocument.pm
+++ b/CreateDocument.pm
@@ -68,12 +68,9 @@ sub get_etherpad_contents {
     $first_found_etherpad =~ s/\/export\/txt//;
 
     my $header = "
-'''<dfn>$event_name</dfn>''' was an IndieWeb meetup on Zoom held on $date_of_event.
+'''<dfn>[$event_page_link $event_name]</dfn>''' was an IndieWeb meetup on Zoom held on $date_of_event.
 
-* $event_page_link
-* When: $date_of_event
 * Archived from: $first_found_etherpad
-
 
     ";
 


### PR DESCRIPTION
This reduces some of the cleanup process by doing a couple of the steps we've been manually doing:
- link the `dfn` to the events.indieweb.org page
- remove the duplicate event date (already appears in the first line)